### PR TITLE
Revise IA planning docs and add strategy guide

### DIFF
--- a/docs/01-epic.md
+++ b/docs/01-epic.md
@@ -1,0 +1,22 @@
+# Epic: Astro Migration – IA Refresh
+
+## Objective
+Recenter the ongoing Gatsby-to-Astro migration around a modern, writing-forward personal site that mirrors the target information architecture and priorities (teaching, writing, AutoSoft Today, consulting, and a refreshed bio) without restarting the project or breaking existing routes.
+
+## Context & Intent
+- Migration is a strategic information architecture refresh, not a 1:1 port of the legacy Gatsby site.
+- The site should feature fewer top-level sections, strong writing posture, clean content collections, and long-term maintainability.
+- Navigation should align to the six-item structure: Home, Teaching, Writing, AutoSoft Today, Consulting, About.
+
+## Constraints
+- Do not restart the project or re-import content.
+- Preserve existing markdown/MDX, slugs, URLs, and content collections; avoid year-based routing.
+- Keep routing stable; focus on layout, navigation, and content modeling realignment.
+- Prefer tags/collections over deep folder nesting; avoid heavy marketing tone.
+
+## Success Criteria
+- Navigation matches the target IA and remains consistent across layouts.
+- Teaching pages feel evergreen with clearly modeled course content for Corporate Innovation and Software Engineering.
+- Writing is the primary content stream, consolidated into a clean collection with tag-driven discoverability (innovation, software engineering, teaching reflections, cycling, guitar/music).
+- AutoSoft Today, Consulting, and About pages present concise, current narratives with outbound links or placeholders where appropriate.
+- Architecture and content modeling support long-term evolution in Astro while honoring locked constraints.

--- a/docs/02-stories.md
+++ b/docs/02-stories.md
@@ -1,0 +1,57 @@
+# Stories for Astro Migration – IA Refresh
+
+## Story 1: Define Top-Level Navigation
+Replace the legacy Gatsby navigation with the six-item IA (Home, Teaching, Writing, AutoSoft Today, Consulting, About) and ensure consistency across layouts.
+
+### Acceptance Criteria
+- Navigation renders the exact six links in all layouts (desktop and mobile if applicable).
+- Existing routes remain functional; new navigation points to the intended pages/collections.
+- No residual Gatsby-era nav items remain.
+
+## Story 2: Create Teaching Section
+Introduce a Teaching landing page plus course subpages for Corporate Innovation and Software Engineering with clear frontmatter for philosophy, topics, example projects, and public artifacts.
+
+### Acceptance Criteria
+- Teaching landing page highlights both courses and links to subpages.
+- Each course page supports defined frontmatter fields and renders them cleanly.
+- Content fits the evergreen tone and avoids year-based URLs.
+
+## Story 3: Consolidate Blog → Writing
+Migrate the blog feed into a Writing collection with tag-driven discovery instead of category pages; ensure hobbies (cycling, guitar/music) live naturally under Writing.
+
+### Acceptance Criteria
+- Writing collection replaces/represents the blog without changing existing slugs.
+- Tags include at least: innovation & org design, software engineering, teaching reflections, cycling, guitar & music.
+- Writing index uses strong post cards with optional images.
+
+## Story 4: AutoSoft Today Landing Page
+Add a concise landing page describing AutoSoft Today, linking out to autosofttoday.com without duplicating content.
+
+### Acceptance Criteria
+- Page explains what AutoSoft Today is and why it matters.
+- Clear external link to autosofttoday.com is present.
+- No imported/duplicated articles from the external site.
+
+## Story 5: Consulting Page
+Create a restrained consulting overview that connects to teaching and writing without heavy sales language.
+
+### Acceptance Criteria
+- Page outlines problems helped with and connection to teaching/writing credibility.
+- Tone remains calm and advisory rather than marketing-heavy.
+- Provides a lightweight contact or next-step cue.
+
+## Story 6: About Page Refresh
+Refresh the bio to reflect current focus, include boards/advisory roles, seasonal location (Seattle/Park City), and a CV link placeholder.
+
+### Acceptance Criteria
+- Bio reads in present tense and foregrounds current work.
+- Sections for roles and location are present; CV link placeholder exists.
+- Page fits within the new navigation and layout system.
+
+## Story 7: Content Audit & Triage
+Audit existing posts/pages to decide what to migrate, retag, or archive while preserving slugs where kept.
+
+### Acceptance Criteria
+- Inventory documents which items migrate as-is, which need retagging, and which are archived/omitted.
+- Recommendations respect locked constraints (no deleted markdown, no route breakage).
+- Follow-up tasks captured for implementation.

--- a/docs/03-workitems.md
+++ b/docs/03-workitems.md
@@ -1,0 +1,38 @@
+# Workitems Supporting Stories
+
+## For Story 1: Define Top-Level Navigation
+1. Inventory current navigation and header components to remove Gatsby-era menu items while preserving route integrity.
+2. Implement the six-link navigation (Home, Teaching, Writing, AutoSoft Today, Consulting, About) in shared layout(s) for desktop and mobile.
+3. Update internal links to point to new/realigned pages or collections without changing existing slugs.
+
+## For Story 2: Create Teaching Section
+1. Draft Teaching landing page structure and content model to highlight Corporate Innovation and Software Engineering.
+2. Define course frontmatter schema (philosophy, topics/frameworks, example projects, public artifacts/links) using content collections.
+3. Create course subpages under the Teaching collection and link them from the Teaching landing page.
+4. Ensure routing avoids year-based paths and remains consistent with locked constraints.
+
+## For Story 3: Consolidate Blog → Writing
+1. Create or update a Writing collection that supersedes the blog while preserving existing post slugs.
+2. Map current categories to the target tag set (innovation & org design, software engineering, teaching reflections, cycling, guitar & music); plan retagging without deleting markdown.
+3. Update the Writing index to use PostCard-style listings with optional images and tag chips.
+4. Validate that existing blog routes resolve and redirect appropriately if needed without breaking URLs.
+
+## For Story 4: AutoSoft Today Landing Page
+1. Draft a concise landing page describing AutoSoft Today’s purpose and current status.
+2. Add prominent external links to autosofttoday.com and representative content highlights without importing that content.
+3. Integrate the page into navigation and ensure layout consistency.
+
+## For Story 5: Consulting Page
+1. Outline consulting positioning (problems solved, connection to teaching/writing) in a restrained tone.
+2. Add a lightweight contact or next-step element that fits existing routing patterns.
+3. Ensure styling aligns with the calm, writing-forward aesthetic (no heavy marketing elements).
+
+## For Story 6: About Page Refresh
+1. Rewrite bio content to foreground current focus areas in present tense and add sections for boards/advisory roles and seasonal location (Seattle/Park City).
+2. Include a CV link placeholder and ensure link handling matches site conventions.
+3. Verify the page uses shared layouts and appears correctly in navigation.
+
+## For Story 7: Content Audit & Triage
+1. Inventory existing posts/pages and categorize them as migrate-as-is, retag, or archive/omit while preserving slugs for kept items.
+2. Document retagging/collection changes needed to align with the new IA and locked constraints.
+3. Capture follow-up implementation tasks and potential redirects (if any) while avoiding deletion of markdown/MDX.

--- a/docs/04-style-guide.md
+++ b/docs/04-style-guide.md
@@ -1,0 +1,37 @@
+# ToddWSeattle Astro Migration – Strategy & Style Guide
+
+Use this guide to keep future work aligned with the IA refresh and writing-first posture. Apply alongside locked constraints (no restart, preserve slugs/routes/content collections, no re-imports).
+
+## Information Architecture Guardrails
+- **Navigation (fixed):** Home, Teaching, Writing, AutoSoft Today, Consulting, About.
+- **Collections (recommended):** `content/writing`, `content/teaching/corporate-innovation`, `content/teaching/software-engineering`, `content/pages`.
+- Prefer tags over deep folder nesting; avoid year-based routing.
+- Writing is the primary stream; hobbies (cycling, guitar) belong as tags under Writing.
+
+## Tone & Content Principles
+- Calm, modern, readable; writing-forward over visual gimmicks.
+- Consulting tone is advisory, not salesy; emphasize credibility from teaching/writing.
+- Teaching pages feel evergreen: philosophy, topics/frameworks, example projects, public artifacts.
+- About is present-tense, current roles, seasonal location (Seattle/Park City), includes CV link placeholder.
+
+## Layout & Styling Notes
+- Maintain shared layouts (Base/Page/Post) with consistent navigation and footer.
+- Favor card-based indexes for Writing with optional imagery; avoid heavy shadows.
+- Typography: Inter for body/headings, JetBrains Mono for code; comfortable prose width (~700px) and line height.
+- Color tokens: background `#FAFAFA`, surface `#FFFFFF`, primary text `#0F172A`, secondary text `#475569`, accent `#4F46E5`.
+- Keep styles declarative; avoid inline hex when Tailwind tokens can be used.
+
+## Content Modeling Checklist
+- Define frontmatter schemas for Teaching courses (philosophy, topics/frameworks, example projects, public artifacts/links).
+- Tag set to standardize Writing: innovation & org design, software engineering, teaching reflections, cycling, guitar & music.
+- When migrating legacy posts, preserve slugs and URLs; retag instead of relocating unless required by IA.
+
+## Validation Expectations
+- Navigation matches the fixed IA; no stray Gatsby-era items.
+- Site builds successfully; routes remain intact; posts render with updated typography and cards.
+- AutoSoft Today page links externally without duplicated content.
+
+## Working Practices
+- Document audit decisions (migrate/retag/archive) without deleting markdown/MDX.
+- Keep diffs focused; prefer small, composable components and declarative styles.
+- If conflicts arise between legacy structure and this guide, refactor toward this plan while honoring locked constraints.


### PR DESCRIPTION
## Summary
- rewrite the epic to reflect the new IA-focused migration objectives and constraints
- replace stories and workitems with ones covering nav, teaching, writing, AutoSoft Today, consulting, about, and content audit
- add a strategy/style guide to keep future work aligned with the refreshed information architecture

## Testing
- not run (documentation-only changes)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6953ed02af8c8332a023d8fa8fb08a79)